### PR TITLE
Suppress warning of implicitly install package.xml file

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,4 @@
+from glob import glob
 from setuptools import setup
 
 package_name = 'urdfdom_py'
@@ -8,8 +9,10 @@ setup(
     package_dir={'': 'src'},
     packages=['urdf_parser_py', 'urdf_parser_py.xml_reflection'],
     data_files=[
-        ('scripts/display_urdf',
-        ['package.xml']),
+        ('share/ament_index/resource_index/packages',
+            ['resource/' + package_name]),
+        ('share/' + package_name, ['package.xml']),
+        ('share/' + package_name + '/scripts', glob('scripts/display_urdf')),
     ],
     install_requires=['setuptools'],
     zip_safe=True,


### PR DESCRIPTION
This PR intends to suppress the warnings that the package.xml is not explicitly installed.

Warning message:
```
WARNING:colcon.colcon_ros.task.ament_python.build:Package 'urdfdom_py' doesn't explicitly install the 'package.xml' file (colcon-ros currently does it implicitly but that fallback will be removed in the future)
```

@henningkayser I think the original [PR](https://github.com/ros/urdf_parser_py/pull/41) to `ros/urdf_parser_py` will not be updated further from AcutronicRobotics. Are we planning to file a new PR?